### PR TITLE
MLIBZ-2024: Set default for generics to definitions file

### DIFF
--- a/src/kinvey.d.ts
+++ b/src/kinvey.d.ts
@@ -170,7 +170,7 @@ export namespace Kinvey {
 
   // DataStore class
   abstract class DataStore {
-    static collection<T extends Entity>(collection: string, type?: DataStoreType, options?: {
+    static collection<T extends Entity = Entity>(collection: string, type?: DataStoreType, options?: {
       client?: Client;
       ttl?: number;
       useDeltaFetch?: boolean;
@@ -179,7 +179,7 @@ export namespace Kinvey {
   }
 
   // NetworkStore class
-  class NetworkStore<T extends Entity> {
+  class NetworkStore<T extends Entity = Entity> {
     protected constructor();
     client: Client;
     pathname: string;
@@ -196,7 +196,7 @@ export namespace Kinvey {
   }
 
   // CacheStore class
-  class CacheStore<T extends Entity> extends NetworkStore<T> {
+  class CacheStore<T extends Entity = Entity> extends NetworkStore<T> {
     clear(query?: Query, options?: RequestOptions): Promise<{ count: number }>;
     pendingSyncCount(query?: Query, options?: RequestOptions): Promise<{ count: number }>;
     pendingSyncEntities(query?: Query, options?: RequestOptions): Promise<SyncEntity[]>;
@@ -207,7 +207,7 @@ export namespace Kinvey {
   }
 
   // SyncStore class
-  class SyncStore<T extends Entity> extends CacheStore<T> {}
+  class SyncStore<T extends Entity = Entity> extends CacheStore<T> {}
 
   // File Metadata interface
   interface FileMetadata {
@@ -231,14 +231,14 @@ export namespace Kinvey {
   // Files class
   class Files {
     static useDeltaFetch: boolean;
-    static find<T extends File>(query?: Query, options?: RequestOptions): Promise<T[]>;
-    static findById<T extends File>(id: string, options?: RequestOptions): Promise<T>;
-    static download<T extends File>(name: string, options?: RequestOptions): Promise<T>;
+    static find<T extends File = File>(query?: Query, options?: RequestOptions): Promise<T[]>;
+    static findById<T extends File = File>(id: string, options?: RequestOptions): Promise<T>;
+    static download<T extends File = File>(name: string, options?: RequestOptions): Promise<T>;
     static downloadByUrl(url: string, options?: RequestOptions): Promise<{}>;
-    static stream<T extends File>(name: string, options?: RequestOptions): Promise<T>;
+    static stream<T extends File = File>(name: string, options?: RequestOptions): Promise<T>;
     static group(aggregation: Aggregation, options?: RequestOptions): Promise<{}>;
     static count(query?: Query, options?: RequestOptions): Promise<{ count: number }>;
-    static upload<T extends File>(file: {}, metadata?: FileMetadata, options?: RequestOptions): Promise<T>;
+    static upload<T extends File = File>(file: {}, metadata?: FileMetadata, options?: RequestOptions): Promise<T>;
     static remove(query?: Query, options?: RequestOptions): Promise<{ count: number }>;
     static removeById(id: string, options?: RequestOptions): Promise<{ count: number }>;
   }

--- a/src/kinvey.d.ts
+++ b/src/kinvey.d.ts
@@ -202,7 +202,7 @@ export namespace Kinvey {
     pendingSyncEntities(query?: Query, options?: RequestOptions): Promise<SyncEntity[]>;
     push(query?: Query, options?: RequestOptions): Promise<PushResult<T>[]>;
     pull(query?: Query, options?: RequestOptions): Promise<T[]>;
-    sync(query?: Query, options?: RequestOptions): { push: PushResult<T>[], pull: T[] };
+    sync(query?: Query, options?: RequestOptions): Promise<{ push: PushResult<T>[], pull: T[] }>;
     clearSync(query?: Query, options?: RequestOptions): Promise<{ count: number }>;
   }
 


### PR DESCRIPTION
#### Description
This PR updates `kinvey.d.ts` to set a default value for generics in the definitions file.

#### Changes
- All data store instances now use `Kinvey.Entity` as the default for the type of generic it will return.
- `FileStore` functions will now use `Kinvey.File` as the default for the type of generic it will return.
- `datastore.sync()` now correctly returns a `Promise`.